### PR TITLE
Enhanced data sealer key strategy bean for caching secret value

### DIFF
--- a/config/shib-idp/conf/global.xml
+++ b/config/shib-idp/conf/global.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+                           
+       default-init-method="initialize"
+       default-destroy-method="destroy">
+
+    <!-- Use this file to define any custom beans needed globally. -->
+
+    <!--
+    Algorithm whitelists and blacklists that override or merge with library defaults. Normally you can leave
+    these empty or commented and use the system defaults, but you can override those defaults using these lists.
+    Each <value> element is an algorithm URI, or you can use <util:constant> elements in place of literal values.
+    -->
+    
+    <!--
+    <util:list id="shibboleth.SignatureWhitelist">
+    </util:list>
+
+    <util:list id="shibboleth.SignatureBlacklist">
+    </util:list>
+
+    <util:list id="shibboleth.EncryptionWhitelist">
+    </util:list>
+
+    <util:list id="shibboleth.EncryptionBlacklist">
+    </util:list>
+    -->
+
+    <!--
+    If you need to define and inject custom Java object(s) into the various views used throughout the
+    system (errors, login, logout, etc.), you can uncomment and define the bean below to be of any
+    type required. It will appear in the view scope as a variable named "custom".
+    
+    The example below defines the bean as a map, which allows you to inject multiple objects under
+    named keys to expand the feature to support multiple injected objects.
+    -->
+    
+    <!--
+    <util:map id="shibboleth.CustomViewContext">
+        <entry key="foo" value="bar"/>
+    </util:map>
+    -->
+    
+    <!-- Retrieve data sealer key from AWS Secrets Manager -->
+    <bean id="awsSecretsManagerDataSealerKeyStrategy" lazy-init="true"
+	class="AWSSecretsManagerKeyStrategy"
+        p:secretId="%{idp.sealer.secretId}"
+        p:updateInterval="%{idp.sealer.updateInterval:PT15M}" />
+
+</beans>

--- a/config/shib-idp/conf/idp.properties
+++ b/config/shib-idp/conf/idp.properties
@@ -28,6 +28,8 @@ idp.cookie.secure = true
 #idp.sealer.versionResource= %{idp.home}/credentials/sealer.kver
 #idp.sealer.storePassword= 90fa668e-ce0f-45e7-82f1-fa4bd0273b51
 #idp.sealer.keyPassword= 90fa668e-ce0f-45e7-82f1-fa4bd0273b51
+idp.sealer.secretId = ${SEALER_KEY_SECRET_ID}
+idp.sealer.keyStrategy = awsSecretsManagerDataSealerKeyStrategy
 
 # Settings for public/private signing and encryption key(s)
 # During decryption key rollover, point the ".2" properties at a second

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ ARG SECRETS_MANAGER_ENCRYPTION_ARN
 ARG SECRETS_MANAGER_SEALER_KEY_ARN
 ARG SECRETS_MANAGER_LDAP_SETTINGS_ARN
 
-ADD config/shib-idp/conf/idp.properties config/shib-idp/conf/ldap.properties config/shib-idp/conf/metadata-providers.xml config/shib-idp/conf/attribute-resolver.xml config/shib-idp/conf/attribute-filter.xml config/shib-idp/conf/saml-nameid.xml /opt/shibboleth-idp/conf/
+ADD config/shib-idp/conf/idp.properties config/shib-idp/conf/ldap.properties config/shib-idp/conf/metadata-providers.xml config/shib-idp/conf/attribute-resolver.xml config/shib-idp/conf/attribute-filter.xml config/shib-idp/conf/saml-nameid.xml config/shib-idp/conf/global.xml /opt/shibboleth-idp/conf/
 ADD config/shib-idp/metadata/idp-metadata.xml /opt/shibboleth-idp/metadata/
 ADD config/shib-idp/metadata/sp /opt/shibboleth-idp/metadata/sp
 ADD config/shib-idp/credentials/ldap-server.truststore /opt/shibboleth-idp/credentials/
@@ -40,11 +40,6 @@ RUN echo "Building the custom DataSealerKeyStrategy implementation that uses AWS
       AWSSecretsManagerKeyStrategy.java -d /opt/shibboleth-idp/edit-webapp/WEB-INF/classes/ && \
     cd ~ && \
     rm -rf /tmp/aws-secrets-manager-build
-
-# Modify the shibboleth global-system.xml file so that it will use our custom AWS Secrets Manager based DataSealerKeyStrategy
-RUN echo "Configuring Shibboleth to use the AWS Secrets Manager based DataSealerKeyStrategy"; \
-    yum install -y xmlstarlet; \
-    xmlstarlet ed -L -d "/_:beans/_:bean[@id='shibboleth.DataSealerKeyStrategy']" -s /_:beans -t elem -n bean -v "" -i /_:beans/bean -t attr -n id -v shibboleth.DataSealerKeyStrategy -i /_:beans/bean -t attr -n class -v AWSSecretsManagerKeyStrategy /opt/shibboleth-idp/system/conf/global-system.xml;
 
 # Install AWS CLI
 RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \


### PR DESCRIPTION
* Improvements to the sealer key strategy bean for caching secret in memory
* Added global.xml that includes instantiation of new bean
* Added properties to idp.properties for use in bean
* Removed code from Dockerfile for modifying global-system.properties

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
