### PR TITLE
Add explicit branch name

### DIFF
--- a/templates/deployment-pipeline.yaml
+++ b/templates/deployment-pipeline.yaml
@@ -54,6 +54,7 @@ Resources:
       RepositoryDescription: Main code repository for holding the Docker build files for the Shibboleth reference architecture
       RepositoryName: !Ref CodeCommitRepoName
       Code:
+        BranchName: master
         S3: 
           Bucket: !Ref RepoSourceBucket
           Key: !Sub '${RepoSourceFolder}repo/code.zip'


### PR DESCRIPTION
*Issue #, if available:* 9

*Description of changes:*

Explicitly add branch name as AWS CodeCommit has changed the default branch name to "main" instead of master

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
