### PR TITLE
Fix for Issue #18 - IAM Role Trust Policy Change

### DIFF
--- a/templates/deployment-pipeline.yaml
+++ b/templates/deployment-pipeline.yaml
@@ -74,6 +74,7 @@ Resources:
           - Effect: Allow
             Principal:
               Service: codebuild.amazonaws.com
+              AWS: "*"
             Action: sts:AssumeRole
 
   CodeBuildServiceRolePolicy:


### PR DESCRIPTION
AWS changed IAM role trust policy behavior when a role assumes itself as detailed at https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/ . The CodeBuildServiceRole must now explicitly list itself for "sts:AssumeRole". This can be done in a brute force manner by allowing all IAM roles.

Issue #18 

Since September 2022, building the image fails with the following error:

```
[Container] 2022/11/01 15:02:07 Entering execCommands
[Container] 2022/11/01 15:02:07 Entering phase INSTALL
[Container] 2022/11/01 15:02:07 Running command TEMP_ROLE=`aws sts assume-role --role-arn $CODE_BUILD_SERVICE_ROLE_ARN --role-session-name test`

An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::123456789:assumed-role/idp-DeploymentPipeli-CodeBuildServiceRole-12345abcde/AWSCodeBuild-abd1234-abcd-1234-abcd-abcd1234is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::123456789:role/idp-DeploymentPipeli-CodeBuildServiceRole-abcd1234

[Container] 2022/11/01 15:02:15 Command did not exit successfully TEMP_ROLE=`aws sts assume-role --role-arn $CODE_BUILD_SERVICE_ROLE_ARN --role-session-name test` exit status 255
[Container] 2022/11/01 15:02:15 Phase complete: INSTALL State: FAILED
[Container] 2022/11/01 15:02:15 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: TEMP_ROLE=`aws sts assume-role --role-arn $CODE_BUILD_SERVICE_ROLE_ARN --role-session-name test`. Reason: exit status 255
```

I have confirmed that this simple patch works for my IdP deployment in AWS. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
