### PR TITLE
Fixes missing ShibbolethVersionTag parameter in -withvpc variant

### DIFF
--- a/aws-shibboleth-idp-withvpc.yaml
+++ b/aws-shibboleth-idp-withvpc.yaml
@@ -251,6 +251,7 @@ Resources:
       TemplateURL: !Sub "https://${TemplateBucket}.s3.amazonaws.com/${TemplateFolder}templates/deployment-pipeline.yaml"
       Parameters:
         Name: !Ref AWS::StackName
+        ShibbolethVersionTag: !Ref ShibbolethVersionTag
         Cluster: !GetAtt Cluster.Outputs.ClusterName
         Service: !GetAtt Service.Outputs.Service
         CodeCommitRepoName: !Ref CodeCommitRepoName


### PR DESCRIPTION
*Description of changes:*

Passes ShibbolethVersionTag CloudFormation parameter in the -withvpc variant to the DeploymentPipeline substack (to match behavior in the -novpc variant)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
